### PR TITLE
Adding docker build infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ project requires first managing the dependencies,
 [Picotls](https://github.com/h2o/picotls)
 and OpenSSL. 
 
+Alternatively, the directory `docker` contains a Dockerfile to build a container for quicdoq - See [Docker README](docker/README.md) for instructions.
+
 ## Quicdoq on Windows
 
 To build Picoquic on Windows, you need to:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:buster-slim
+ENV DOQ_PORT=784 DOQ_DESTINATION=8.8.8.8
+RUN apt-get update && apt-get install cmake git ca-certificates libssl-dev build-essential pkg-config --no-install-recommends -y
+# dependencies - picotls
+RUN git clone https://github.com/h2o/picotls /var/tmp/picotls
+WORKDIR /var/tmp/picotls
+RUN git submodule init && git submodule update
+RUN cmake . && make 
+# dependencies - picoquic
+RUN git clone https://github.com/private-octopus/picoquic /var/tmp/picoquic
+WORKDIR /var/tmp/picoquic
+RUN cmake . && make
+# quicdoq itself
+RUN git clone https://github.com/private-octopus/quicdoq /var/tmp/quicdoq
+WORKDIR /var/tmp/quicdoq
+RUN cmake . && make
+RUN cp quicdoq_app /bin && mkdir /etc/picoquic && cp ../picoquic/certs/cert.pem /etc/picoquic/cert.pem && cp ../picoquic/certs/key.pem /etc/picoquic/key.pem
+RUN cd /var/tmp && rm -rf quicdoq picoquic picotls
+RUN dpkg --purge build-essential pkg-config libssl-dev cmake
+RUN apt-get -y autoremove && apt-get clean && rm -f /var/lib/apt/lists/*_*
+WORKDIR /bin
+EXPOSE ${DOQ_PORT}/udp
+CMD ./quicdoq_app -c /etc/picoquic/cert.pem -k /etc/picoquic/key.pem -p ${DOQ_PORT} -d ${DOQ_DESTINATION}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,50 @@
+# DNS over QUIC container
+
+Alex Mayrhofer <alexander.mayrhofer@nic.at>, July 2021
+
+This Dockerfile builds (and starts) a simple DNS over QUIC (DoQ) proxy - as a "proof of concept" level container, based on the DoQ proxy `quicdoq` (https://github.com/private-octopus/quicdoq). 
+
+When run, the container will start `quicdoq` in server mode, listening on port 784/udp (by default). The container will forward received DNS queries to 8.8.8.8 by default (see configuration below).
+
+## Building the container
+
+```
+docker build .
+```
+
+## Running the container
+
+```
+docker run -d --name quicdoq_server -p 784:784/udp <image id>
+```
+
+## Configuration
+
+The default port (784) and default forwarding destination (8.8.8.8) can be changed using environment variables as follows:
+
+  * **DOQ_PORT**: Sets the UDP port number that quicdoq_app will listen on, defaults to 784
+  * **DOQ_DESTINATION**: Sets the IP address of the upstream nameserver to be used. Defaults to 8.8.8.8
+
+Configuration can be performed from the `docker run` command as follows:
+
+```
+docker run -d --name quicdoq_server -p 8853:8853/udp --env DOQ_PORT=8853 --env DOQ_DESTINATION=1.1.1.1 <image id>
+```
+
+(Alternatively, a `docker-compose` file can be used, of course)
+
+## Sending a query 
+
+To send a query, `quicdoq_app` can be used from within the container as well. In order to do this, open a shell into the same container, and use the binary in client mode from within the container as follows:
+
+```
+docker exec -it <container id> /bin/bash
+./quicdoq_app localhost 784 www.nic.at:AAAA
+```
+
+## Open issues
+
+  * clean up build environment in image
+  * `quicdoq` itself is probably not using the latest -03 version of the protocol (which added a 2-byte header). This doesn't matter if the only client is quicdoq itself, but obviously hinders interopability ;)
+
+


### PR DESCRIPTION
Hi Christian,

i've added a small docker file that builds quicdoq within a docker container, and therefore creates a "DoQ proxy container image". Port as well as forwarding destination can be configured via environment variables at runtime.

We're using that image internally for research purposes, and i think others could benefit as well.

best,
Alex
